### PR TITLE
Better auto exit

### DIFF
--- a/Source/JobGiver_Patch.cs
+++ b/Source/JobGiver_Patch.cs
@@ -7,7 +7,7 @@ namespace Shashlichnik
 {
     public static class JobGiver_Patch
     {
-        public static string[] overridingJobDefNames = new string[] { "LayDown" };
+        public static string[] overridingJobDefNames = new string[] { "LayDown", "Ingest" };
 
         private static void TryOverrideJob(Pawn pawn, ref Job job)
         {
@@ -19,18 +19,54 @@ namespace Shashlichnik
                 if (caveComp != null && caveComp.caveExit != null && caveComp.caveExit.Spawned &&
                     caveComp.caveExit.exitIfNoJob)
                 {
-                    Log.Message($"Detected overridable job [{val}]. Redirecting the pawn to exit cave instead.");
-                    var oldjob = job;
-                    JobMaker.ReturnToPool(oldjob); // Return the old job to the pool
-                    // make a new one
-                    job = JobMaker.MakeJob(JobDefOf.EnterPortal, caveComp.caveExit);
+                    // Check if this is a hunger-related job and pawn can't find food in the cave
+                    if (val == "Ingest" && !CanFindFoodInCave(pawn, caveComp))
+                    {
+                        Log.Message($"Detected hunger but no food available in cave. Redirecting pawn to exit cave.");
+                        var oldjob = job;
+                        JobMaker.ReturnToPool(oldjob); // Return the old job to the pool
+                        // make a new one
+                        job = JobMaker.MakeJob(JobDefOf.EnterPortal, caveComp.caveExit);
+                    }
+                    // Check if this is sleeping on floor (original functionality)
+                    else if (val == "LayDown")
+                    {
+                        Log.Message($"Detected overridable job [{val}]. Redirecting the pawn to exit cave instead.");
+                        var oldjob = job;
+                        JobMaker.ReturnToPool(oldjob); // Return the old job to the pool
+                        // make a new one
+                        job = JobMaker.MakeJob(JobDefOf.EnterPortal, caveComp.caveExit);
+                    }
                 }
             }
         }
 
+        private static bool CanFindFoodInCave(Pawn pawn, CaveMapComponent caveComp)
+        {
+            Map caveMap = caveComp.caveExit.Map;
+            
+            // Look for any food sources in the cave that the pawn can access
+            var foodSources = caveMap.listerThings.ThingsInGroup(ThingRequestGroup.FoodSourceNotPlantOrTree)
+                .Where(food => food.def.IsNutritionGivingIngestible && 
+                              !food.IsForbidden(pawn) && 
+                              pawn.CanReach(food, PathEndMode.OnCell, Danger.Deadly));
+            
+            return foodSources.Any();
+        }
+
         // patch return result
-        [HarmonyLib.HarmonyPatch(typeof(JobGiver_GetRest), nameof(JobGiver_GetRest.TryGiveJob))]
+        [HarmonyLib.HarmonyPatch(typeof(JobGiver_GetRest), "TryGiveJob")]
         internal static class GetRest_TryGiveJob_Patch
+        {
+            public static void Postfix(Pawn pawn, ref Job __result)
+            {
+                TryOverrideJob(pawn, ref __result);
+            }
+        }
+
+        // patch return result for food (hunger)
+        [HarmonyLib.HarmonyPatch(typeof(JobGiver_GetFood), "TryGiveJob")]
+        internal static class GetFood_TryGiveJob_Patch
         {
             public static void Postfix(Pawn pawn, ref Job __result)
             {

--- a/Source/JobGiver_Patch.cs
+++ b/Source/JobGiver_Patch.cs
@@ -11,23 +11,18 @@ namespace Shashlichnik
 
         private static void TryOverrideJob(Pawn pawn, ref Job job)
         {
-            Log.Message($"[JobGiver_Patch] Checking job for pawn {pawn.Name}: [{job?.def?.defName}]");
-            
+            // Log.Message($"job is [{job?.def?.defName}]");
             if (job?.def?.defName is { } val
                 && overridingJobDefNames.Contains(val))
             {
-                Log.Message($"[JobGiver_Patch] Found overridable job: {val}");
-                
                 var caveComp = pawn.Map.GetComponent<CaveMapComponent>();
-                Log.Message($"[JobGiver_Patch] Cave component: {caveComp != null}, exit: {caveComp?.caveExit != null}, spawned: {caveComp?.caveExit?.Spawned}, exitIfNoJob: {caveComp?.caveExit?.exitIfNoJob}");
-                
                 if (caveComp != null && caveComp.caveExit != null && caveComp.caveExit.Spawned &&
                     caveComp.caveExit.exitIfNoJob)
                 {
                     // Check if this is a hunger-related job and pawn can't find food in the cave
                     if (val == "Ingest" && !CanFindFoodInCave(pawn, caveComp))
                     {
-                        Log.Message($"[JobGiver_Patch] Detected hunger but no food available in cave. Redirecting pawn to exit cave.");
+                        Log.Message($"Detected hunger but no food available in cave. Redirecting pawn to exit cave.");
                         var oldjob = job;
                         JobMaker.ReturnToPool(oldjob); // Return the old job to the pool
                         // make a new one
@@ -36,20 +31,12 @@ namespace Shashlichnik
                     // Check if this is sleeping on floor (original functionality)
                     else if (val == "LayDown")
                     {
-                        Log.Message($"[JobGiver_Patch] Detected overridable job [{val}]. Redirecting the pawn to exit cave instead.");
+                        Log.Message($"Detected overridable job [{val}]. Redirecting the pawn to exit cave instead.");
                         var oldjob = job;
                         JobMaker.ReturnToPool(oldjob); // Return the old job to the pool
                         // make a new one
                         job = JobMaker.MakeJob(JobDefOf.EnterPortal, caveComp.caveExit);
                     }
-                    else
-                    {
-                        Log.Message($"[JobGiver_Patch] Job {val} not handled or conditions not met");
-                    }
-                }
-                else
-                {
-                    Log.Message($"[JobGiver_Patch] Cave exit conditions not met for override");
                 }
             }
         }
@@ -73,7 +60,6 @@ namespace Shashlichnik
         {
             public static void Postfix(Pawn pawn, ref Job __result)
             {
-                Log.Message($"[JobGiver_Patch] GetRest patch called for {pawn.Name}, result: {__result?.def?.defName}");
                 TryOverrideJob(pawn, ref __result);
             }
         }
@@ -84,7 +70,18 @@ namespace Shashlichnik
         {
             public static void Postfix(Pawn pawn, ref Job __result)
             {
-                Log.Message($"[JobGiver_Patch] GetFood patch called for {pawn.Name}, result: {__result?.def?.defName}");
+                // If no food job was created, check if we should exit cave due to hunger
+                if (__result == null)
+                {
+                    var caveComp = pawn.Map.GetComponent<CaveMapComponent>();
+                    if (caveComp != null && caveComp.caveExit != null && caveComp.caveExit.Spawned &&
+                        caveComp.caveExit.exitIfNoJob && !CanFindFoodInCave(pawn, caveComp))
+                    {
+                        Log.Message($"{pawn.Name} found no food in cave. Giving exit job.");
+                        __result = JobMaker.MakeJob(JobDefOf.EnterPortal, caveComp.caveExit);
+                    }
+                }
+                
                 TryOverrideJob(pawn, ref __result);
             }
         }

--- a/Source/JobGiver_Patch.cs
+++ b/Source/JobGiver_Patch.cs
@@ -11,18 +11,23 @@ namespace Shashlichnik
 
         private static void TryOverrideJob(Pawn pawn, ref Job job)
         {
-            // Log.Message($"job is [{job?.def?.defName}]");
+            Log.Message($"[JobGiver_Patch] Checking job for pawn {pawn.Name}: [{job?.def?.defName}]");
+            
             if (job?.def?.defName is { } val
                 && overridingJobDefNames.Contains(val))
             {
+                Log.Message($"[JobGiver_Patch] Found overridable job: {val}");
+                
                 var caveComp = pawn.Map.GetComponent<CaveMapComponent>();
+                Log.Message($"[JobGiver_Patch] Cave component: {caveComp != null}, exit: {caveComp?.caveExit != null}, spawned: {caveComp?.caveExit?.Spawned}, exitIfNoJob: {caveComp?.caveExit?.exitIfNoJob}");
+                
                 if (caveComp != null && caveComp.caveExit != null && caveComp.caveExit.Spawned &&
                     caveComp.caveExit.exitIfNoJob)
                 {
                     // Check if this is a hunger-related job and pawn can't find food in the cave
                     if (val == "Ingest" && !CanFindFoodInCave(pawn, caveComp))
                     {
-                        Log.Message($"Detected hunger but no food available in cave. Redirecting pawn to exit cave.");
+                        Log.Message($"[JobGiver_Patch] Detected hunger but no food available in cave. Redirecting pawn to exit cave.");
                         var oldjob = job;
                         JobMaker.ReturnToPool(oldjob); // Return the old job to the pool
                         // make a new one
@@ -31,12 +36,20 @@ namespace Shashlichnik
                     // Check if this is sleeping on floor (original functionality)
                     else if (val == "LayDown")
                     {
-                        Log.Message($"Detected overridable job [{val}]. Redirecting the pawn to exit cave instead.");
+                        Log.Message($"[JobGiver_Patch] Detected overridable job [{val}]. Redirecting the pawn to exit cave instead.");
                         var oldjob = job;
                         JobMaker.ReturnToPool(oldjob); // Return the old job to the pool
                         // make a new one
                         job = JobMaker.MakeJob(JobDefOf.EnterPortal, caveComp.caveExit);
                     }
+                    else
+                    {
+                        Log.Message($"[JobGiver_Patch] Job {val} not handled or conditions not met");
+                    }
+                }
+                else
+                {
+                    Log.Message($"[JobGiver_Patch] Cave exit conditions not met for override");
                 }
             }
         }
@@ -60,6 +73,7 @@ namespace Shashlichnik
         {
             public static void Postfix(Pawn pawn, ref Job __result)
             {
+                Log.Message($"[JobGiver_Patch] GetRest patch called for {pawn.Name}, result: {__result?.def?.defName}");
                 TryOverrideJob(pawn, ref __result);
             }
         }
@@ -70,6 +84,7 @@ namespace Shashlichnik
         {
             public static void Postfix(Pawn pawn, ref Job __result)
             {
+                Log.Message($"[JobGiver_Patch] GetFood patch called for {pawn.Name}, result: {__result?.def?.defName}");
                 TryOverrideJob(pawn, ref __result);
             }
         }


### PR DESCRIPTION
# Add hunger-based auto-exit feature

Hey! I really liked your idea for the auto-exit thing after seeing your pull request on the main repository. I figured it would be cool if it also applied to hunger, so pawns wouldn't starve to death while mining. I expanded your patch with hunger detection and attempting to leave the cave if no food is found in the cave itself. 

## Summary

- Extended JobGiver_Patch to detect when pawns are hungry with no accessible food in caves
- Added CanFindFoodInCave method to check for available food sources
Pawns now automatically exit caves when hungry and no food is available (when "Exit if no work" is enabled)

Since you already have a pull request open for this, and my changes are dependent on yours, I think it's best if we merge if we potentially merge my changes into this into your branch, and then this gets included in the main PR. 

Let me know if you're interested in combining our changes!🤩